### PR TITLE
Implement master password functionality

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -121,6 +121,10 @@ def main():
         print("ENCRYPTION_KEY generated and saved.")
 
     if args.command == "setpass":
+        if os.getenv("ENCRYPTED_MASTER_PASSWORD"):
+            print("Master password already set.")
+            return
+
         set_master_password(args.master_password, encryption_key.encode())
         return
 

--- a/cli.py
+++ b/cli.py
@@ -6,21 +6,33 @@ from dotenv import load_dotenv
 
 from models import Password, SessionLocal, init_db
 
-load_dotenv()
-
-key = os.getenv("PASSWORD_MANAGER_KEY")
-if not key:
-    raise EnvironmentError(
-        "Encryption key not found. Set the PASSWORD_MANAGER_KEY environment variable."
-    )
-
-cipher = Fernet(key.encode("utf-8"))
-
 init_db()
 session = SessionLocal()
 
 
-def add_password(service_name, service_url, username, plain_password):
+def generate_key():
+    key = Fernet.generate_key()
+    return key
+
+
+def encrypt_master_password(master_password, key):
+    cipher = Fernet(key)
+    encrypted_password = cipher.encrypt(master_password.encode())
+    return encrypted_password
+
+
+def verify_master_password(input_password, encrypted_password, key):
+    cipher = Fernet(key)
+
+    try:
+        decrypted_password = cipher.decrypt(encrypted_password).decode()
+        return decrypted_password == input_password
+
+    except Exception as e:
+        return False
+
+
+def add_password(service_name, service_url, username, plain_password, cipher):
     """Add a new password entry to the database."""
     password = Password(
         service_name=service_name,
@@ -33,7 +45,7 @@ def add_password(service_name, service_url, username, plain_password):
     print(f"Password for {service_name} added successfully!")
 
 
-def retrieve_password(service_name):
+def retrieve_password(service_name, cipher):
     """Retrieve a password entry by service name."""
     password = (
         session.query(Password).filter(Password.service_name == service_name).first()
@@ -61,6 +73,14 @@ def list_passwords():
         print("No passwords stored yet.")
 
 
+def set_master_password(input_password, encryption_key):
+    encrypted_master_password = encrypt_master_password(input_password, encryption_key)
+    with open(".env", "a") as f:
+        f.write(f"ENCRYPTED_MASTER_PASSWORD={encrypted_master_password.decode()}\n")
+
+    print("Master password set successfully!")
+
+
 # CLI setup
 def main():
     parser = argparse.ArgumentParser(description="Password Manager CLI")
@@ -80,16 +100,56 @@ def main():
     # List command
     list_parser = subparsers.add_parser("list", help="List all stored passwords")
 
+    # Setpass command
+    setpass_parser = subparsers.add_parser("setpass", help="Set the master password")
+    setpass_parser.add_argument(
+        "master_password", help="Master password for the password manager"
+    )
+
     # Parse arguments
     args = parser.parse_args()
 
-    # Handle commands
+    load_dotenv()
+    encryption_key = os.getenv("ENCRYPTION_KEY")
+
+    if not encryption_key:
+        encryption_key = generate_key().decode()
+
+        with open(".env", "a") as f:
+            f.write(f"ENCRYPTION_KEY={encryption_key}\n")
+
+        print("ENCRYPTION_KEY generated and saved.")
+
+    if args.command == "setpass":
+        set_master_password(args.master_password, encryption_key.encode())
+        return
+
+    input_password = input("Enter your master password: ")
+    stored_encrypted_password = os.getenv("ENCRYPTED_MASTER_PASSWORD")
+    if stored_encrypted_password:
+        # Decrypt the stored password and verify
+        if verify_master_password(
+            input_password, stored_encrypted_password.encode(), encryption_key.encode()
+        ):
+            print("Master password verified successfully!")
+        else:
+            print("Incorrect master password.")
+            return
+
     if args.command == "add":
+        cipher = Fernet(encryption_key)
         add_password(
-            args.service_name, args.service_url, args.username, args.plain_password
+            args.service_name,
+            args.service_url,
+            args.username,
+            args.plain_password,
+            cipher,
         )
+
     elif args.command == "retrieve":
-        retrieve_password(args.service_name)
+        cipher = Fernet(encryption_key)
+        retrieve_password(args.service_name, cipher)
+
     elif args.command == "list":
         list_passwords()
 


### PR DESCRIPTION
Summary:
This PR reworks the PASSWORD_MANAGER_KEY functionality to instead use an encrypted master password for more security.

Changes:
- Added functions to generate a key, encrypt the master password and verify it
- Added a 'setpass' CLI command to set the master password
- Added a seperate ENCRYPTION_KEY (replaces PASSWORD_MANAGER_KEY) environment variable to use for encrypting and decrypting passwords on the database

Why:
If someone were to get access to the user's computer, this would prevent them from seeing the passwords stored. The user only has to remember ONE password, which is also why this makes things simpler at the same time.