### PR TITLE
Implement a random password generator function

### DIFF
--- a/models.py
+++ b/models.py
@@ -10,7 +10,6 @@ class Password(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     service_name = Column(String(100), nullable=False)
-    service_url = Column(String(200), nullable=True)
     username = Column(String(100), nullable=False)
     encrypted_password = Column(String(256), nullable=False)
 


### PR DESCRIPTION
Summary:
This PR introduces a basic optional CLI command to generate a secure random password.

Changes:
- Added a CLI command 'generate' with an optional argument for password length (default is 16 characters)
- Added a flag command '--generate'  for when adding or updating a password. It also automatically stores the newly generated password as the replacement.
- 
Why:
Makes it easier to create a new password quickly on the spot.